### PR TITLE
Fix example to use 'type_' instead of 'type'

### DIFF
--- a/flask_sillywalk/sillywalk.py
+++ b/flask_sillywalk/sillywalk.py
@@ -88,7 +88,7 @@ class SwaggerApiRegistry(object):
 
         Usage:
 
-        >>> @my_registry.registerModel(type="Animal")
+        >>> @my_registry.registerModel(type_="Animal")
         >>> class Dog(object):
         >>>     def __init__(self):
         >>>     pass


### PR DESCRIPTION
The example does not seem to work.  Adding a trailing underscore fixes it.
